### PR TITLE
APB-7299 [CS] add cbc to supported services (behind FF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 
 # agent-user-client-details
 
-This microservice is used for creating and maintaining Agent Access Groups. It supports the frontend microservice agent-permissions-frontend along with agent-permissions. It's primary function is to orchestrate changes in EACD after an Access Group has been created or modified. 
+This microservice is used for creating and maintaining Agent Access Groups. It supports the frontend microservice agent-permissions-frontend along with agent-permissions.
+
+It's primary function is to orchestrate changes in EACD after an Access Group has been created or modified.
+
+It also contains the following to support the display of a client list within ASA:
+- ES3 cache used for retrieving a full client list (ASA supported services*)
+- Friendly name fetch to backfill missing friendly names (async process)
+
+*Note: Personal Income Record is not currently supported for access groups, although it is listed in agent-mtd-identifiers 
+
 
 ## Endpoints
 

--- a/app/uk/gov/hmrc/agentuserclientdetails/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentuserclientdetails/config/AppConfig.scala
@@ -87,6 +87,8 @@ trait AppConfig {
   val userGroupsSearchUrl: String
 
   val es3MaxRecordsFetchCount: Int
+
+  val enableCbcFeature: Boolean
 }
 
 @Singleton
@@ -174,4 +176,6 @@ class AppConfigImpl @Inject() (servicesConfig: ServicesConfig) extends AppConfig
 
   lazy val userGroupsSearchUrl: String = servicesConfig.baseUrl("users-groups-search")
   override lazy val es3MaxRecordsFetchCount: Int = servicesConfig.getInt("es3.max-records-fetch-count")
+
+  override lazy val enableCbcFeature: Boolean = servicesConfig.getBoolean("features.enable-cbc")
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -232,3 +232,7 @@ fieldLevelEncryption {
 # Timeout in order to decide when an instance is no longer running.
 # Must be higher than the heartbeat interval (service-job.intervalSeconds)
 serviceInstanceCounter.timeout = 120s
+
+features {
+  enable-cbc = true
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,7 +10,7 @@ object AppDependencies {
 
   val compile = Seq(
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-work-item-repo-play-28" % mongoVer,
-    "uk.gov.hmrc"             %% "agent-mtd-identifiers"             % "1.12.0",
+    "uk.gov.hmrc"             %% "agent-mtd-identifiers"             % "1.13.0",
     "uk.gov.hmrc"             %% "cluster-work-throttling"           % "8.5.0-play-28",
     "uk.gov.hmrc"             %% "agent-kenshoo-monitoring"          % "5.4.0",
     "uk.gov.hmrc"             %% "crypto-json-play-28"               % "7.3.0",

--- a/test/uk/gov/hmrc/agentuserclientdetails/support/TestAppConfig.scala
+++ b/test/uk/gov/hmrc/agentuserclientdetails/support/TestAppConfig.scala
@@ -62,4 +62,5 @@ class TestAppConfig extends AppConfig {
   val serviceJobIntervalSeconds: Int = 60
   val serviceJobInitialDelaySeconds: Int = 60
   override val es3MaxRecordsFetchCount: Int = 1000
+  override val enableCbcFeature: Boolean = true
 }


### PR DESCRIPTION
Allows cbc/cbc-non uk clients to be saved in the ES3 cache

Edit: Prod config has been merged.
Prod config PR: https://github.com/hmrc/app-config-production/pull/19145