### PR TITLE
removes references to non-existent caches in test suites

### DIFF
--- a/it/test/uk/gov/hmrc/agentuserclientdetails/connectors/CitizenDetailsConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/agentuserclientdetails/connectors/CitizenDetailsConnectorISpec.scala
@@ -22,7 +22,6 @@ import play.api.http.Status
 import play.api.libs.json.Json
 import uk.gov.hmrc.agentuserclientdetails.BaseIntegrationSpec
 import uk.gov.hmrc.agentuserclientdetails.config.AppConfig
-import uk.gov.hmrc.agentuserclientdetails.services.AgentCacheProvider
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
@@ -34,7 +33,6 @@ import scala.concurrent.{ExecutionContext, Future}
 class CitizenDetailsConnectorISpec extends BaseIntegrationSpec with MockFactory {
 
   lazy val appConfig = app.injector.instanceOf[AppConfig]
-  lazy val cache = app.injector.instanceOf[AgentCacheProvider]
   lazy val metrics = app.injector.instanceOf[Metrics]
   lazy val desIfHeaders = app.injector.instanceOf[DesIfHeaders]
   implicit val hc: HeaderCarrier = HeaderCarrier()

--- a/it/test/uk/gov/hmrc/agentuserclientdetails/connectors/DesConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/agentuserclientdetails/connectors/DesConnectorISpec.scala
@@ -24,7 +24,6 @@ import uk.gov.hmrc.agentmtdidentifiers.model.{CgtRef, MtdItId, Vrn}
 import uk.gov.hmrc.agentuserclientdetails.BaseIntegrationSpec
 import uk.gov.hmrc.agentuserclientdetails.config.AppConfig
 import uk.gov.hmrc.agentuserclientdetails.model._
-import uk.gov.hmrc.agentuserclientdetails.services.AgentCacheProvider
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
@@ -36,7 +35,6 @@ import scala.concurrent.{ExecutionContext, Future}
 class DesConnectorISpec extends BaseIntegrationSpec with MockFactory {
 
   lazy val appConfig = app.injector.instanceOf[AppConfig]
-  lazy val cache = app.injector.instanceOf[AgentCacheProvider]
   lazy val metrics = app.injector.instanceOf[Metrics]
   lazy val desIfHeaders = app.injector.instanceOf[DesIfHeaders]
   implicit val hc: HeaderCarrier = HeaderCarrier()
@@ -124,7 +122,7 @@ class DesConnectorISpec extends BaseIntegrationSpec with MockFactory {
       )(
         httpClient
       )
-      val ifConnector = new IfConnectorImpl(appConfig, cache, httpClient, metrics, desIfHeaders)
+      val ifConnector = new IfConnectorImpl(appConfig, httpClient, metrics, desIfHeaders)
       ifConnector.getTradingDetailsForMtdItId(testMtdItId).futureValue should matchPattern {
         case Some(TradingDetails(Nino("ZR987654C"), Some("Surname DADTN"))) =>
       }

--- a/it/test/uk/gov/hmrc/agentuserclientdetails/connectors/IfConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/agentuserclientdetails/connectors/IfConnectorISpec.scala
@@ -24,7 +24,6 @@ import uk.gov.hmrc.agentmtdidentifiers.model.{PptRef, Urn, Utr}
 import uk.gov.hmrc.agentuserclientdetails.BaseIntegrationSpec
 import uk.gov.hmrc.agentuserclientdetails.config.AppConfig
 import uk.gov.hmrc.agentuserclientdetails.model.PptSubscription
-import uk.gov.hmrc.agentuserclientdetails.services.AgentCacheProvider
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.metrics.Metrics
@@ -35,7 +34,6 @@ import scala.concurrent.{ExecutionContext, Future}
 class IfConnectorISpec extends BaseIntegrationSpec with MockFactory {
 
   lazy val appConfig = app.injector.instanceOf[AppConfig]
-  lazy val cache = app.injector.instanceOf[AgentCacheProvider]
   lazy val metrics = app.injector.instanceOf[Metrics]
   lazy val desIfHeaders = app.injector.instanceOf[DesIfHeaders]
   implicit val hc: HeaderCarrier = HeaderCarrier()
@@ -65,7 +63,7 @@ class IfConnectorISpec extends BaseIntegrationSpec with MockFactory {
       mockHttpGet(s"${appConfig.ifPlatformBaseUrl}/trusts/agent-known-fact-check/URN/${testUrn.value}", mockResponse)(
         httpClient
       )
-      val ifConnector = new IfConnectorImpl(appConfig, cache, httpClient, metrics, desIfHeaders)
+      val ifConnector = new IfConnectorImpl(appConfig, httpClient, metrics, desIfHeaders)
       ifConnector.getTrustName(testUrn.value).futureValue shouldBe Some("Friendly Trust")
     }
     "getTrustName (UTR)" in {
@@ -75,7 +73,7 @@ class IfConnectorISpec extends BaseIntegrationSpec with MockFactory {
       mockHttpGet(s"${appConfig.ifPlatformBaseUrl}/trusts/agent-known-fact-check/UTR/${testUtr.value}", mockResponse)(
         httpClient
       )
-      val ifConnector = new IfConnectorImpl(appConfig, cache, httpClient, metrics, desIfHeaders)
+      val ifConnector = new IfConnectorImpl(appConfig, httpClient, metrics, desIfHeaders)
       ifConnector.getTrustName(testUtr.value).futureValue shouldBe Some("Friendly Trust")
     }
     "getPptSubscription (individual)" in {
@@ -98,7 +96,7 @@ class IfConnectorISpec extends BaseIntegrationSpec with MockFactory {
         s"${appConfig.ifPlatformBaseUrl}/plastic-packaging-tax/subscriptions/PPT/${testPptRef.value}/display",
         mockResponse
       )(httpClient)
-      val ifConnector = new IfConnectorImpl(appConfig, cache, httpClient, metrics, desIfHeaders)
+      val ifConnector = new IfConnectorImpl(appConfig, httpClient, metrics, desIfHeaders)
       ifConnector.getPptSubscription(testPptRef).futureValue shouldBe Some(PptSubscription("Bill Sikes"))
     }
     "getPptSubscription (organisation)" in {
@@ -120,7 +118,7 @@ class IfConnectorISpec extends BaseIntegrationSpec with MockFactory {
         s"${appConfig.ifPlatformBaseUrl}/plastic-packaging-tax/subscriptions/PPT/${testPptRef.value}/display",
         mockResponse
       )(httpClient)
-      val ifConnector = new IfConnectorImpl(appConfig, cache, httpClient, metrics, desIfHeaders)
+      val ifConnector = new IfConnectorImpl(appConfig, httpClient, metrics, desIfHeaders)
       ifConnector.getPptSubscription(testPptRef).futureValue shouldBe Some(PptSubscription("Friendly Organisation"))
     }
   }

--- a/it/test/uk/gov/hmrc/agentuserclientdetails/controllers/ClientControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentuserclientdetails/controllers/ClientControllerISpec.scala
@@ -63,7 +63,6 @@ class ClientControllerISpec extends BaseIntegrationSpec with MongoSupport with A
 
   lazy val jobMonitoringRepository = new JobMonitoringRepository(mongoComponent, config)
   lazy val jobMonitoringService = new JobMonitoringServiceImpl(jobMonitoringRepository, appConfig)
-  lazy val agentCacheProvider = app.injector.instanceOf[AgentCacheProvider]
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
   val testGroupId = "2K6H-N1C1-7M7V-O4A3"
@@ -104,8 +103,7 @@ class ClientControllerISpec extends BaseIntegrationSpec with MongoSupport with A
     val clientNameService = new ClientNameService(
       citizenDetailsConnector,
       desConnector,
-      ifConnector,
-      agentCacheProvider
+      ifConnector
     )
     val controller = new ClientController(
       cc,

--- a/test/uk/gov/hmrc/agentuserclientdetails/services/AssignmentsWorkerSpec.scala
+++ b/test/uk/gov/hmrc/agentuserclientdetails/services/AssignmentsWorkerSpec.scala
@@ -37,7 +37,7 @@ import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class AssignmentsWorkerSpec extends AnyWordSpec with Matchers with MockFactory with FakeCache {
+class AssignmentsWorkerSpec extends AnyWordSpec with Matchers with MockFactory {
 
   val testUserId = "ABCEDEFGI1234568"
   val testEnrolmentKey = "HMRC-MTD-VAT~VRN~12345678"

--- a/test/uk/gov/hmrc/agentuserclientdetails/services/ClientNameServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentuserclientdetails/services/ClientNameServiceSpec.scala
@@ -21,12 +21,12 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.agentuserclientdetails.services.ClientNameService.InvalidServiceIdException
-import uk.gov.hmrc.agentuserclientdetails.support.{FakeCache, FakeCitizenDetailsConnector, FakeDesConnector, FakeIfConnector}
+import uk.gov.hmrc.agentuserclientdetails.support.{FakeCitizenDetailsConnector, FakeDesConnector, FakeIfConnector}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ClientNameServiceSpec extends AnyWordSpec with Matchers with FakeCache {
+class ClientNameServiceSpec extends AnyWordSpec with Matchers {
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
   val cns = new ClientNameService(

--- a/test/uk/gov/hmrc/agentuserclientdetails/services/FriendlyNameWorkerSpec.scala
+++ b/test/uk/gov/hmrc/agentuserclientdetails/services/FriendlyNameWorkerSpec.scala
@@ -39,7 +39,7 @@ import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class FriendlyNameWorkerSpec extends AnyWordSpec with Matchers with MockFactory with FakeCache {
+class FriendlyNameWorkerSpec extends AnyWordSpec with Matchers with MockFactory {
 
   val testGroupId = "2K6H-N1C1-7M7V-O4A3"
 

--- a/test/uk/gov/hmrc/agentuserclientdetails/services/JobMonitoringWorkerSpec.scala
+++ b/test/uk/gov/hmrc/agentuserclientdetails/services/JobMonitoringWorkerSpec.scala
@@ -36,7 +36,7 @@ import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class JobMonitoringWorkerSpec extends AnyWordSpec with Matchers with MockFactory with FakeCache {
+class JobMonitoringWorkerSpec extends AnyWordSpec with Matchers with MockFactory {
 
   val groupId = "myGroupId"
   val client1 = Client("HMRC-MTD-VAT~VRN~000000001", "Frank Wright")


### PR DESCRIPTION
to fix build job issues since Nov although I'm not 100% sure we should have removed the agency-details cache. Let's double check usage before deploying to prod.